### PR TITLE
added admin link for direct access as part of the message.

### DIFF
--- a/app/code/community/Mhauri/Slack/Model/Observers/NewOrder.php
+++ b/app/code/community/Mhauri/Slack/Model/Observers/NewOrder.php
@@ -22,9 +22,10 @@
  * @author Marcel Hauri <marcel@hauri.me>, Sander Mangel <https://github.com/sandermangel>
  */
 
-class Mhauri_Slack_Model_Observers_NewOrder
- extends Mhauri_Slack_Model_Observers_Abstract
+class Mhauri_Slack_Model_Observers_NewOrder extends Mhauri_Slack_Model_Observers_Abstract
 {
+
+    private $_order_url = '';
 
     /**
      * Get customer name
@@ -49,9 +50,11 @@ class Mhauri_Slack_Model_Observers_NewOrder
     public function notify($observer)
     {
         $_order = $observer->getOrder();
+        $this->_order_url = Mage::helper('adminhtml')->getUrl('adminhtml/sales_order/view/order_id/',['order_id'=> $_order->getId()]);
 
         if($this->_getConfig(Mhauri_Slack_Model_Notification::NEW_ORDER_PATH)) {
-            $message = $this->_helper->__("*A new order has been placed.* \n*Order ID:* %s, *Name:* %s, *Amount:* %s %s",
+            $message = $this->_helper->__("*A new order has been placed.* \n*Order ID:* <%s|%s>, *Name:* %s, *Amount:* %s %s",
+                $this->_order_url,
                 $_order->getIncrementId(),
                 $this->getCustomerName($_order),
                 $_order->getQuoteBaseGrandTotal(),


### PR DESCRIPTION
Order number will be now given as a clickable url so you can be taken to the order directly with a single click (as long as you're logged into your store admin and have permissions).

![slack](https://cloud.githubusercontent.com/assets/123676/20656425/ac6df32c-b591-11e6-875b-3a77f6aef25a.png)

Tested on : 
- 1.7.0.2
- 1.9.3.1